### PR TITLE
fixed docker compose issue

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,17 +4,23 @@ import (
 	"log"
 	"net/http"
 
+	"Learning-Mode-AI-Ai-Service/pkg/config"
 	"Learning-Mode-AI-Ai-Service/pkg/handlers"
 	"Learning-Mode-AI-Ai-Service/pkg/services"
-
 	"github.com/gorilla/mux"
+	"github.com/joho/godotenv"
 )
 
-func main() {
-	// Initialize OpenAI client and Redis connection
-	services.InitOpenAIClient()
+func init() {
+	err := godotenv.Load(".env")
+	if err != nil {
+		log.Fatal("Error loading .env file")
+	}
+	config.InitConfig()
 	services.InitRedis()
+}
 
+func main() {
 	// Set up router
 	r := mux.NewRouter()
 

--- a/dockerfile
+++ b/dockerfile
@@ -29,7 +29,7 @@ WORKDIR /root/
 COPY --from=builder /app/main . 
 
 # Ensure .env file is in the correct place
-COPY --from=builder /app/.env ../
+COPY --from=builder /app/.env .
 
 # Expose the application port (adjust if different)
 EXPOSE 8082

--- a/pkg/services/gpt_service.go
+++ b/pkg/services/gpt_service.go
@@ -10,8 +10,6 @@ import (
 	"os"
 	"sync"
 	"time"
-
-	"github.com/joho/godotenv"
 )
 
 type ThreadManager struct {
@@ -32,12 +30,6 @@ type InitializeRequest struct {
 	Transcript         string `json:"transcript"`
 }
 
-// Initialize the OpenAI client and load the API key
-func InitOpenAIClient() {
-	if err := godotenv.Load("../.env"); err != nil {
-		log.Fatalf("Error loading .env file: %v", err)
-	}
-}
 
 // CreateAssistantWithMetadata creates a new assistant based on YouTube video metadata
 func CreateAssistantWithMetadata(initReq InitializeRequest) (string, error) {


### PR DESCRIPTION
The command `COPY --from=builder /app/.env .`  copies the .env file into the docker container, this does not however copy the environment variable (`ENVIRONMENT=docker`). In order to fix the issue we implement the init function which uses godotenv to load the environment variable from the file that we copied over into the container using the copy command above.