### PR TITLE
Better Prompt, Redis Caching For Summary

### DIFF
--- a/pkg/services/gpt_service.go
+++ b/pkg/services/gpt_service.go
@@ -444,11 +444,11 @@ func GenerateSummary(transcript string) (string, error) {
         return "", fmt.Errorf("transcript is empty")
     }
 
-    systemPrompt := "You are a helpful assistant that summarizes video transcripts."
-    prompt := fmt.Sprintf("Summarize the following video transcript concisely:\n\n%s", transcript)
+    systemPrompt := "You are a professional assistant specializing in summarizing video content. Your summaries should be structured, concise, and focused on the key ideas, themes, and takeaways from the video. Exclude unnecessary details or repetitive information. Present the summary in a clear and organized format with headings if applicable."
+	prompt := fmt.Sprintf("Please summarize the following video transcript. Focus on the key topics, main arguments, and actionable takeaways. Exclude irrelevant details, filler, or repetitive information. Organize the summary into the following sections:\n\n1. Title and Overview: Briefly introduce the video and its main purpose.\n2. Key Points: Outline the major ideas, concepts, or arguments presented.\n3. Conclusion: Summarize the overall message or conclusions drawn in the video.\n\nTranscript:\n%s", transcript)
 
     temperature := 0.8
-	maxTokens := 10000
+	maxTokens := 16000
     response, err := CallGPT(prompt, systemPrompt, temperature, maxTokens)
     if err != nil {
         return "", fmt.Errorf("GPT call failed: %v", err)
@@ -482,7 +482,7 @@ func CallGPT(prompt, systemPrompt string, temperature float64, maxTokens int) (s
     req.Header.Set("Content-Type", "application/json")
     req.Header.Set("Authorization", "Bearer "+os.Getenv("OPENAI_API_KEY"))
 
-    client := &http.Client{Timeout: 15 * time.Second}
+    client := &http.Client{Timeout: 60 * time.Second}
     resp, err := client.Do(req)
     if err != nil {
         return "", fmt.Errorf("GPT API call failed: %v", err)

--- a/pkg/services/gpt_service.go
+++ b/pkg/services/gpt_service.go
@@ -445,7 +445,7 @@ func GenerateSummary(transcript string) (string, error) {
     }
 
     systemPrompt := "You are a professional assistant specializing in summarizing video content. Your summaries should be structured, concise, and focused on the key ideas, themes, and takeaways from the video. Exclude unnecessary details or repetitive information. Present the summary in a clear and organized format with headings if applicable."
-	prompt := fmt.Sprintf("Please summarize the following video transcript. Focus on the key topics, main arguments, and actionable takeaways. Exclude irrelevant details, filler, or repetitive information. Organize the summary into the following sections:\n\n1. Title and Overview: Briefly introduce the video and its main purpose.\n2. Key Points: Outline the major ideas, concepts, or arguments presented.\n3. Conclusion: Summarize the overall message or conclusions drawn in the video.\n\nTranscript:\n%s", transcript)
+	prompt := fmt.Sprintf("Please summarize the following video transcript. Focus on the key topics, main arguments, and actionable takeaways. Exclude irrelevant details, filler, or repetitive information, title of the video. Organize the summary into the following sections:\n\n1. Overview: Briefly introduce the video and its main purpose.\n2. Key Points: Outline the major ideas, concepts, or arguments presented.\n3. Conclusion: Summarize the overall message or conclusions drawn in the video.\n\nTranscript:\n%s", transcript)
 
     temperature := 0.8
 	maxTokens := 16000

--- a/pkg/services/redis_service.go
+++ b/pkg/services/redis_service.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"fmt"
 	"github.com/go-redis/redis/v8"
+	"time"
 )
 
 var (
@@ -43,3 +44,14 @@ func GetTranscriptFromRedis(videoID string) (string, error) {
     return val, nil
 }
 
+func StoreSummaryInRedis(videoID string, summary string) error {
+	return RedisClient.Set(Ctx, "summary:"+videoID, summary, 24*time.Hour).Err()
+}
+
+func GetSummaryFromRedis(videoID string) (string, error) {
+	summary, err := RedisClient.Get(Ctx, "summary:"+videoID).Result()
+	if err == redis.Nil {
+		return "", nil
+	}
+	return summary, err
+}


### PR DESCRIPTION
This PR introduces a caching mechanism using Redis to avoid redundant summary generation for the AI Service. The `GenerateSummaryHandler` now checks Redis before calling the summary generation logic. If a summary exists in the cache, it is returned directly. Otherwise, the transcript is retrieved from Redis, a summary is generated, and the result is stored back in Redis for future use. A new prompt was added to create a more structured output for the user, however still has some inconsistencies (Still undergoing change).

**Key Changes:**

- **New Redis Key:** `"summary:{videoID}"` (stores video summary as a string with a 24-hour TTL)
- Updated `generateSummaryHandler.go` to check Redis for an existing summary.
- Added `StoreSummaryInRedis` and `GetSummaryFromRedis` methods in `redis_service.go`.

**Data Flow:**

1. **Client Request:** The client sends a request for a video summary to the AI service.
2. **Redis Cache Check:** The AI service checks Redis using the key `"summary:{videoID}"`.
3. **Cache Hit:** If the summary is found, it is returned directly.
4. **Cache Miss:** If not found, the service retrieves the transcript from Redis and generates a new summary.
5. **Caching:** The newly generated summary is stored in Redis with a 24-hour TTL for future requests.
