### PR TITLE
Added port 6379 to local host again

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,7 +21,7 @@ func InitConfig() {
 	TLSEnabled = tlsEnabled
 
 	if env == "local" {
-		RedisHost = "localhost"
+		RedisHost = "localhost:6379"
 		TLSEnabled = false
 		fmt.Println("Running in local mode")
 	} else {


### PR DESCRIPTION
In a previous change by someone the local host port was deleted hence if you tried running locally the service would not work. The issue was not caught because the other person failed to test locally. I added the port back in config.go