### PR TITLE
Changed the prompt to not add letters when giving the options. LEA-83

### DIFF
--- a/pkg/services/gpt_service.go
+++ b/pkg/services/gpt_service.go
@@ -455,7 +455,7 @@ func GenerateQuiz(transcript string) (map[string]interface{}, error) {
 		return nil, fmt.Errorf("transcript is empty")
 	}
 	systemPrompt := "You are a helpful assistant that generates multiple choice questions given the full video transcript."
-	prompt := fmt.Sprintf("Generate 10 multiple-choice questions in structured JSON format based on the following transcript. Each question must have exactly one correct answer. If multiple valid answers are mentioned in the transcript, only include one of them as part of the options. The questions should be based on the transcript and should not be outside the transcript. Ensure that the answer field exactly matches one of the provided options. Transcript:\n\n%s", transcript)
+	prompt := fmt.Sprintf("Generate 10 multiple-choice questions in structured JSON format based on the following transcript. Each question must have exactly one correct answer. If multiple valid answers are mentioned in the transcript, only include one of them as part of the options. The questions should be based on the transcript and should not be outside the transcript. Ensure that the answer field exactly matches one of the provided options. Do NOT add any letters like 'A, B, C, D' before the options. Just provide the options. Transcript:\n\n%s", transcript)
 	response, err := CallGPT2(prompt, systemPrompt)
 	if err != nil {
 		return nil, fmt.Errorf("GPT call failed: %v", err)


### PR DESCRIPTION
added this part in the prompt for the generate quiz function . "Do NOT add any letters like 'A, B, C, D' before the options. Just provide the options". Tested both on openai playground platform and on many youtube videos on youtube seems to fix the issue.