### PR TITLE
Changed prompt text

### DIFF
--- a/pkg/services/gpt_service.go
+++ b/pkg/services/gpt_service.go
@@ -412,7 +412,7 @@ func (tm *ThreadManager) GetThreadMessages() ([]Message, error) {
 func createPrompt(question string, timestamp int) string {
 	// Format the timestamp as mm:ss
 	// Create the prompt by appending the timestamp to the question
-	return fmt.Sprintf("At the timestamp <%d>, user asks: %s, Give a response based on the context of the video around the timestamp", timestamp, question)
+	return fmt.Sprintf("At the timestamp <%d>, user asks: %s, Give a response based on the context of the video around the timestamp. Don't include the timestamp in your response. Sound natural, and human", timestamp, question)
 }
 
 type TextContent struct {


### PR DESCRIPTION
Chatbox does not display time stamp anymore, and sounds more human.  LEA-72

e.g.:
*User input* "Explain what a software engineers job is"

*Old AI Output* "At this time stamp <21> Software engineering is the branch of computer science that deals with the design, development..."

*AI Output* "Software engineering is the branch of computer science that deals with the design, development..."

https://linear.app/learningmodeai/issue/LEA-72/improve-prompt-for-chat-bot-feature